### PR TITLE
reverting kafka iam permissions

### DIFF
--- a/pxa_lambda_iam.tf
+++ b/pxa_lambda_iam.tf
@@ -43,9 +43,15 @@ resource "aws_iam_policy" "lambda_secrets_manager_policy" {
         Action = [
           "secretsmanager:GetSecretValue",
           "secretsmanager:DescribeSecret",
-          "secretsmanager:ListSecrets"
         ]
         Resource = "arn:aws:secretsmanager:${var.AWS_REGION}:${data.aws_caller_identity.current.account_id}:secret:${local.pxa_prefix}-*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:ListSecrets"
+        ]
+        Resource = "*"
       }
     ]
   })

--- a/pxa_lambda_iam.tf
+++ b/pxa_lambda_iam.tf
@@ -37,36 +37,17 @@ resource "aws_iam_policy" "lambda_secrets_manager_policy" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = concat(
-      [
-        {
-          Effect = "Allow"
-          Action = [
-            "secretsmanager:GetSecretValue",
-            "secretsmanager:DescribeSecret",
-            "secretsmanager:ListSecrets"
-          ]
-          Resource = "arn:aws:secretsmanager:${var.AWS_REGION}:${data.aws_caller_identity.current.account_id}:secret:${local.pxa_prefix}-*"
-        }
-      ],
-      local.msk.arn != null ? [
-        {
-          Effect = "Allow"
-          Action = [
-            "kafka-cluster:Connect",
-            "kafka-cluster:DescribeTopic",
-            "kafka-cluster:WriteData",
-            "kafka-cluster:DescribeGroup",
-            "kafka-cluster:CreateTopic"
-          ]
-          Resource = [
-            local.msk.arn,
-            "${replace(local.msk.arn, ":cluster/", ":topic/")}/*",
-            "${replace(local.msk.arn, ":cluster/", ":group/")}/*",
-          ]
-        }
-      ] : []
-    )
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecrets"
+        ]
+        Resource = "arn:aws:secretsmanager:${var.AWS_REGION}:${data.aws_caller_identity.current.account_id}:secret:${local.pxa_prefix}-*"
+      }
+    ]
   })
 }
 

--- a/pxa_locals.tf
+++ b/pxa_locals.tf
@@ -16,26 +16,7 @@ locals {
   }
 
   users = {
-    "app" = merge(
-      {},
-      local.msk.arn != null ? {
-        "kafka-policy" = {
-          "effect" = "Allow"
-          "actions" = [
-            "kafka-cluster:Connect",
-            "kafka-cluster:DescribeTopic",
-            "kafka-cluster:ReadData",
-            "kafka-cluster:DescribeGroup",
-            "kafka-cluster:AlterGroup"
-          ]
-          "resource" = [
-            local.msk.arn,
-            "${replace(local.msk.arn, ":cluster/", ":topic/")}/*",
-            "${replace(local.msk.arn, ":cluster/", ":group/")}/*",
-          ]
-        }
-      } : {}
-    )
+    "app"    = {}
     "static" = {}
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Lambda IAM permissions by removing Kafka/MSK integration support and conditional policy logic
  * Lambda service now exclusively manages Secrets Manager access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->